### PR TITLE
Fix Email link

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You can see our meeting times on [this calendar](https://calendar.google.com/cal
 
 - [Discourse](https://discourse.nixos.org/c/dev/marketing-team/28)
 - [Matrix](https://matrix.to/#/#marketing:nixos.org)
-- [Email](webmaster@nixos.org)
+- [Email](mailto:webmaster@nixos.org)
 
 If you have a time sensitve marketing need, reach out on Matrix.
 


### PR DESCRIPTION
Missing `mailto:` resulted in Email link being a non-existent Github web page.
Did not fix email address being to the wrong canonical address.